### PR TITLE
Marker comp for the ouroboros

### DIFF
--- a/Content.Shared/_Impstation/Weapons/Ranged/Components/OuroborousAmmoMarkerComponent.cs
+++ b/Content.Shared/_Impstation/Weapons/Ranged/Components/OuroborousAmmoMarkerComponent.cs
@@ -1,0 +1,10 @@
+namespace Content.Shared._Impstation.Weapons.Ranged.Components;
+
+/// <summary>
+/// I'm not entirely sure what you need this for DVD but you can fill this out.
+/// </summary>
+[RegisterComponent]
+public sealed partial class OuroborousAmmoMarkerComponent : Component
+{
+
+}


### PR DESCRIPTION
adds an empty marker comp for the ouroboros at `Content.Shared/_Impstation/Weapons/Ranged/Components`
